### PR TITLE
Corrected the URL scheme format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Elasticsearch) connections.
 
 To setup a connection, the driver requires a JDBC connection URL. The connection URL is of the form:
 ```
-    jdbc:elasticsearch://[scheme:][host][:port][/context-path]?[property-key=value]&[property-key2=value2]..&[property-keyN=valueN]
+    jdbc:elasticsearch://[scheme://][host][:port][/context-path]?[property-key=value]&[property-key2=value2]..&[property-keyN=valueN]
 ```
 
 


### PR DESCRIPTION
*Description of changes:*

When specifying the scheme parameter of the URL, the :// characters must follow it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
