### PR TITLE
Accept null 'columnNamePattern' on DatabaseMetaData.getColumns() - #11

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/DatabaseMetaDataImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/DatabaseMetaDataImpl.java
@@ -1217,7 +1217,9 @@ public class DatabaseMetaDataImpl implements DatabaseMetaData, JdbcWrapper, Logg
         ColumnMetadataStatement(ConnectionImpl connection, String tableNamePattern, String columnNamePattern, Logger log)
                 throws SQLException {
             // TODO - once sql plugin supports PreparedStatement fully, do this through a preparedStatement with params
-            super(connection, "DESCRIBE TABLES LIKE " + tableNamePattern + " COLUMNS LIKE " + columnNamePattern, log);
+            super(connection, "DESCRIBE TABLES LIKE " + tableNamePattern +
+                (columnNamePattern != null ? (" COLUMNS LIKE " + columnNamePattern) : ""),
+                log);
         }
 
         static class ColumnMetadataResultSet extends ResultSetImpl {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/DatabaseMetaDataTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/DatabaseMetaDataTests.java
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.jdbc;
 
+import com.amazon.opendistroforelasticsearch.jdbc.DatabaseMetaDataImpl.ColumnMetadataStatement;
 import com.amazon.opendistroforelasticsearch.jdbc.config.ConnectionConfig;
 import com.amazon.opendistroforelasticsearch.jdbc.logging.NoOpLogger;
 import com.amazon.opendistroforelasticsearch.jdbc.protocol.ClusterMetadata;
@@ -366,6 +367,24 @@ public class DatabaseMetaDataTests {
         assertEmptySchemaResultSet(dbmd.getSchemas("some-cat", "%"));
         assertEmptySchemaResultSet(dbmd.getSchemas("mock-cluster", "some-schema"));
         assertEmptySchemaResultSet(dbmd.getSchemas(null, "some-schema"));
+    }
+    
+    @Test
+    void testGetColumnsWithoutColumnNamePattern() throws Exception {
+        Connection con = getMockConnection();
+        
+        ColumnMetadataStatement stmt = new ColumnMetadataStatement((ConnectionImpl)con, "TABLE_%", null, NoOpLogger.INSTANCE);
+        assertEquals("DESCRIBE TABLES LIKE TABLE_%", stmt.sql);
+        assertDoesNotThrow(stmt::close);
+    }
+    
+    @Test
+    void testGetColumnsWithColumnNamePattern() throws Exception {
+        Connection con = getMockConnection();
+        
+        ColumnMetadataStatement stmt = new ColumnMetadataStatement((ConnectionImpl)con, "TABLE_%", "COLUMN_%", NoOpLogger.INSTANCE);
+        assertEquals("DESCRIBE TABLES LIKE TABLE_% COLUMNS LIKE COLUMN_%", stmt.sql);
+        assertDoesNotThrow(stmt::close);
     }
 
     private void assertValidSchemaResultSet(ResultSet rs) throws SQLException {


### PR DESCRIPTION
*Issue #, if available:* #11 

*Description of changes:*

Changes constructor of `DatabaseMetaDataImpl.ColumnMetadataStatement` to allow null on `columnNamePattern` parameter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
