### PR TITLE
Support IP type in JDBC driver

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -66,6 +66,7 @@ public enum ElasticsearchType {
     SCALED_FLOAT(JDBCType.DOUBLE, Double.class, 15, 25, true),
     KEYWORD(JDBCType.VARCHAR, String.class, 256, 0, false),
     TEXT(JDBCType.VARCHAR, String.class, Integer.MAX_VALUE, 0, false),
+    IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
     DATE(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     NULL(JDBCType.NULL, null, 0, 0, false),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/types/KeywordTypeTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/types/KeywordTypeTests.java
@@ -1,0 +1,30 @@
+package com.amazon.opendistroforelasticsearch.jdbc.types;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KeywordTypeTests {
+
+    @ParameterizedTest
+    @MethodSource("validIpStringProvider")
+    void testIpFromValidIpString(String stringValue, String expectedValue) {
+        String result = Assertions.assertDoesNotThrow(
+                () -> StringType.INSTANCE.fromValue(stringValue, null));
+        assertEquals(expectedValue, result);
+    }
+
+    private static Stream<Arguments> validIpStringProvider() {
+        return Stream.of(
+                Arguments.of("199.72.81.55", "199.72.81.55"),
+                Arguments.of("205.212.115.106", "205.212.115.106"),
+                Arguments.of("255.255.255.255", "255.255.255.255"),
+                Arguments.of("255.0.0.0", "255.0.0.0")
+        );
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

* [**Issue 272 in sql (sibling repository): IP field types are currently not supported.**](https://github.com/opendistro-for-elasticsearch/sql/issues/272)

*Description of changes:*

* Supported IP type in JDBC driver
* Added unit test and sanity tested through DbVisualizer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
