### PR TITLE
Adding missing Elasticsearch type `object`

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -68,6 +68,7 @@ public enum ElasticsearchType {
     TEXT(JDBCType.VARCHAR, String.class, Integer.MAX_VALUE, 0, false),
     IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
+    OBJECT(JDBCType.STRUCT, null, 0, 0, false),
     DATE(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     NULL(JDBCType.NULL, null, 0, 0, false),
     UNSUPPORTED(JDBCType.OTHER, null, 0, 0, false);


### PR DESCRIPTION
*Issue :* #44 

*Description of changes:*
Added missing Elasticsearch type : object. 


**Note:** Reviewers please verify the parameters for the enum. I believe it should be `(JDBCType.STRUCT, String.class, Integer.MAX_VALUE, 0, false)`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
