### PR TITLE
Revert "OD 1.5.0.0 Release (#56)"

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - name: Set up JDK 1.13
+    - name: Set up JDK 1.12
       uses: actions/setup-java@v1
       with:
-        java-version: 1.13
+        java-version: 1.12
     
     - name: Build with Gradle
       run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ plugins {
 group 'com.amazon.opendistroforelasticsearch.client'
 
 // keep version in sync with version in Driver source
-version '1.5.0.0'
+version '1.4.0.0'
 
 version = "${version}"
 

--- a/opendistro-elasticsearch-jdbc.release-notes.md
+++ b/opendistro-elasticsearch-jdbc.release-notes.md
@@ -1,7 +1,4 @@
-## 2019-03-09, Version 1.5.0.0 (Current)
-* No update in this release.
-
-## 2019-1-26, Version 1.4.0
+## 2019-1-26, Version 1.4.0 (Current)
 
 ### Features
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/internal/Version.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/internal/Version.java
@@ -19,7 +19,7 @@ package com.amazon.opendistroforelasticsearch.jdbc.internal;
 public enum Version {
 
     // keep this in sync with the gradle version
-    Current(1, 5, 0, 0);
+    Current(1, 4, 0, 0);
 
     private int major;
     private int minor;


### PR DESCRIPTION
This reverts commit 355a7e54c074068a26e82796d5e61099557578ac.

*Issue #, if available:*

*Description of changes:*
Used wrong version number. Revert to 1.4.0.0, skip 1.5.0.0 and prepare for release 1.6.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
