### PR TITLE
Use default holdability for prepareStatement method

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/ConnectionImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/ConnectionImpl.java
@@ -279,7 +279,7 @@ public class ConnectionImpl implements ElasticsearchConnection, JdbcWrapper, Log
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
         log.debug(() -> logEntry("prepareStatement (%s, %d, %d)", sql, resultSetType, resultSetConcurrency));
         checkOpen();
-        validateResultSetCharacteristics(resultSetType, resultSetConcurrency, resultSetConcurrency);
+        validateResultSetCharacteristics(resultSetType, resultSetConcurrency, ResultSet.HOLD_CURSORS_OVER_COMMIT);
         PreparedStatement pst = prepareStatementX(sql);
         log.debug(() -> logExit("prepareStatement", pst));
         return pst;


### PR DESCRIPTION
Fixes #63 

This PR correctly passes default of `ResultSet.HOLD_CURSORS_OVER_COMMIT` to `validateResultSetCharacteristics` when `prepareStatement` is called without result set foldability setting.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
