### PR TITLE
Bug Fix, change the request body encoding to UTF-8

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/transport/http/ApacheHttpTransport.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/transport/http/ApacheHttpTransport.java
@@ -42,6 +42,7 @@ import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -259,7 +260,7 @@ public class ApacheHttpTransport implements HttpTransport, LoggingSource {
             setReadTimeout(readTimeout);
             HttpPost request = new HttpPost(uri);
             request.setHeaders(headers);
-            request.setEntity(new StringEntity(body));
+            request.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
             request.setConfig(getRequestConfig());
             return httpClient.execute(request);
         } catch (IOException e) {


### PR DESCRIPTION
*Issue #, if available: #54, #66, https://github.com/opendistro-for-elasticsearch/sql/issues/392

*Description of changes: Change the request body encoding to UTF-8 instead the default ISO_8859_1

### Test
There is no integration test for JDBC driver now. Manual test the feature and create the issue https://github.com/opendistro-for-elasticsearch/sql-jdbc/issues/67 to tracking the JDBC integration test. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
